### PR TITLE
changed update file tag to main

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-files:
-    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@1.0.0
+    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@main
     secrets:
       AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
       SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,7 +22,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/modules/private/README.md
+++ b/modules/private/README.md
@@ -31,7 +31,7 @@ Example available [here](https://github.com/boldlink/terraform-aws-ecr/tree/main
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 

--- a/modules/public/README.md
+++ b/modules/public/README.md
@@ -33,7 +33,7 @@ This sub-module Provides a Public Elastic Container Registry Repository.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
 
 ## Modules
 


### PR DESCRIPTION
This PR changes update workflow tag to main.
This will ensure only the recent workflow is will run.
It also ensures no manual changes will be done to the update file in case there is an update to the reusable workflow.